### PR TITLE
Add a64 (32-bit userspace on 64-bit kernel) targets DAG30 & DAV30

### DIFF
--- a/buildbot_unified.sh
+++ b/buildbot_unified.sh
@@ -116,8 +116,10 @@ build_device() {
 
 build_treble() {
     case "${1}" in
+        ("DAG30") TARGET=a64_gapps30;;
         ("DG30") TARGET=gapps30;;
         ("DG31") TARGET=gapps31;;
+        ("DAV30") TARGET=a64_vanilla30;;
         ("DV30") TARGET=vanilla30;;
         ("DV31") TARGET=vanilla31;;
         (*) echo "Invalid target - exiting"; exit 1;;


### PR DESCRIPTION
May be enough to build bootable images for F22 non-Pro; as previously shared in Duoqin Hacking community by `melezx`. Submitting this here to avoid forgetting about it since people seem interested in using the previously published image :)

Keep in mind I didn't locally test this nor have the device in question; the shared zip also had this diff to a seemingly already generated `device/phh/treble/AndroidProducts.mk` (though I dropped `31` variants since they'd be unused):
```diff
--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -1,4 +1,6 @@
 PRODUCT_MAKEFILES := \
+	$(LOCAL_DIR)/lineage_a64_gapps30.mk \
+	$(LOCAL_DIR)/lineage_a64_vanilla30.mk \
 	$(LOCAL_DIR)/lineage_gapps31.mk \
 	$(LOCAL_DIR)/lineage_vanilla31.mk \
 	$(LOCAL_DIR)/lineage_gapps30.mk \
```
otherwise I also saw `vendor/hardware_overlay/TrebleApp/app.apk` and `treble_app/sdk/.knownPackages` were changed as well but the diff only said "binary differs", maybe done by scripts automatically?). The relevant files here are possibly autogenerated (too?): [dumberos_untracked_20260522.tar.gz](https://github.com/user-attachments/files/29659505/dumberos_untracked_20260522.tar.gz)
